### PR TITLE
Adding Copy Post URL

### DIFF
--- a/src/booru/browser.cc
+++ b/src/booru/browser.cc
@@ -204,6 +204,15 @@ void Browser::on_copy_image_url()
     m_StatusBar->set_message(_("Copied image URL to clipboard"));
 }
 
+void Browser::on_copy_post_url()
+{
+    const std::shared_ptr<Image> image =
+        std::static_pointer_cast<Image>(get_active_page()->get_imagelist()->get_current());
+
+    Gtk::Clipboard::get()->set_text(image->get_post_url());
+    m_StatusBar->set_message(_("Copied post URL to clipboard"));
+}
+
 void Browser::on_realize()
 {
     Gtk::VPaned::on_realize();

--- a/src/booru/browser.h
+++ b/src/booru/browser.h
@@ -42,6 +42,7 @@ namespace AhoViewer
             void on_save_images();
             void on_view_post();
             void on_copy_image_url();
+            void on_copy_post_url();
             // }}}
         protected:
             virtual void on_realize() override;

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -471,6 +471,10 @@ void MainWindow::create_actions()
             _("Copy Image URL"), _("Copy the selected image's URL to your clipboard")),
             Gtk::AccelKey(Settings.get_keybinding("BooruBrowser", "CopyImageURL")),
             sigc::mem_fun(m_BooruBrowser, &Booru::Browser::on_copy_image_url));
+    m_ActionGroup->add(Gtk::Action::create("CopyPostURL", Gtk::Stock::COPY,
+            _("Copy Post URL"), _("Copy the selected image's post URL to your clipboard")),
+            Gtk::AccelKey(Settings.get_keybinding("BooruBrowser", "CopyPostURL")),
+            sigc::mem_fun(m_BooruBrowser, &Booru::Browser::on_copy_post_url));
     // }}}
 
     // Toggle actions {{{

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -129,6 +129,7 @@ SettingsManager::SettingsManager()
                 { "SaveImages",          "<Primary><Shift>s" },
                 { "ViewPost",            "<Primary><Shift>o" },
                 { "CopyImageURL",        "y"                 },
+                { "CopyPostURL",         "<Primary>y"                 },
             }
         }
     }),

--- a/src/ui.glade
+++ b/src/ui.glade
@@ -1842,6 +1842,7 @@
         <separator/>
         <menuitem action="ViewPost"/>
         <menuitem action="CopyImageURL"/>
+        <menuitem action="CopyPostURL"/>
       </popup>
     </ui>
   </object>


### PR DESCRIPTION
I'm not a big fan of hotlinking images from boorus, because I use them myself and often find the post page more helpful. Some of my friends, though, prefer to use ahoviewer to browse, and would like to skip the step of opening the browser to copy post URL - so I attempted to add it to the application.