### PR TITLE
booru: use a different TempDir for each tab

### DIFF
--- a/src/booru/imagelist.h
+++ b/src/booru/imagelist.h
@@ -12,13 +12,16 @@ namespace AhoViewer
         {
         public:
             ImageList(Widget *w);
+            virtual ~ImageList() override;
 
+            std::string get_path();
             virtual size_t get_size() const override { return m_Size ? m_Size : AhoViewer::ImageList::get_size(); }
             size_t get_vector_size() const { return m_Images.size(); }
 
             virtual void clear() override;
             void load(const xmlDocument &posts, const Page &page);
         private:
+            std::string m_Path;
             size_t m_Size;
         };
     }

--- a/src/booru/site.cc
+++ b/src/booru/site.cc
@@ -1,12 +1,12 @@
 #include <chrono>
 #include <fstream>
 #include <iostream>
+#include <glib/gstdio.h>
 
 #include "site.h"
 using namespace AhoViewer::Booru;
 
 #include "settings.h"
-#include "tempdir.h"
 
 #ifdef HAVE_LIBSECRET
 #include <libsecret/secret.h>
@@ -291,17 +291,6 @@ void Site::cleanup_cookie() const
     if ((m_Username.empty() || m_Password.empty() || m_NewAccount) &&
             Glib::file_test(m_CookiePath, Glib::FILE_TEST_EXISTS))
         g_unlink(m_CookiePath.c_str());
-}
-
-std::string Site::get_path()
-{
-    if (m_Path.empty())
-    {
-        m_Path = TempDir::get_instance().make_dir(m_Name);
-        g_mkdir_with_parents(Glib::build_filename(m_Path, "thumbnails").c_str(), 0755);
-    }
-
-    return m_Path;
 }
 
 Glib::RefPtr<Gdk::Pixbuf> Site::get_icon_pixbuf(const bool update)

--- a/src/booru/site.h
+++ b/src/booru/site.h
@@ -67,7 +67,6 @@ namespace AhoViewer
             std::string get_cookie();
             void cleanup_cookie() const;
 
-            std::string get_path();
             Glib::RefPtr<Gdk::Pixbuf> get_icon_pixbuf(const bool update = false);
 
             void save_tags() const;
@@ -95,8 +94,7 @@ namespace AhoViewer
                         m_Password,
                         m_IconPath,
                         m_TagsPath,
-                        m_CookiePath,
-                        m_Path;
+                        m_CookiePath;
             Type m_Type;
             bool m_NewAccount;
             uint64_t m_CookieTS;


### PR DESCRIPTION
The directory is automatically removed to save RAM when you close the tab. This helps a lot when doing long browsing sessions.