### PR TITLE
Added Save Image without dialog

### DIFF
--- a/src/booru/browser.cc
+++ b/src/booru/browser.cc
@@ -165,21 +165,23 @@ void Browser::on_save_image()
 
     if (!m_LastSavePath.empty())
     {
-        get_active_page()->save_image(m_LastSavePath + "/" + Glib::path_get_basename(image->get_filename()), image);
+        get_active_page()->save_image(
+            m_LastSavePath + "/" + Glib::path_get_basename(image->get_filename()), image);
     }
-    else{
-		auto* window{ static_cast<Gtk::Window*>(get_toplevel()) };
-		auto dialog{ Gtk::FileChooserNative::create(
-			"Save Image As", *window, Gtk::FILE_CHOOSER_ACTION_SAVE) };
-		dialog->set_modal();
+    else
+    {
+        auto* window{ static_cast<Gtk::Window*>(get_toplevel()) };
+        auto dialog{ Gtk::FileChooserNative::create(
+            "Save Image As", *window, Gtk::FILE_CHOOSER_ACTION_SAVE) };
+        dialog->set_modal();
 
-		dialog->set_current_name(Glib::path_get_basename(image->get_filename()));
-		if (dialog->run() == Gtk::RESPONSE_ACCEPT)
-		{
-			std::string path = dialog->get_filename();
-			m_LastSavePath   = Glib::path_get_dirname(path);
-			get_active_page()->save_image(path, image);
-		}
+        dialog->set_current_name(Glib::path_get_basename(image->get_filename()));
+        if (dialog->run() == Gtk::RESPONSE_ACCEPT)
+        {
+            std::string path = dialog->get_filename();
+            m_LastSavePath   = Glib::path_get_dirname(path);
+            get_active_page()->save_image(path, image);
+        }
     }
 }
 

--- a/src/booru/browser.cc
+++ b/src/booru/browser.cc
@@ -167,6 +167,8 @@ void Browser::on_save_image()
 
         get_active_page()->save_image(
             m_LastSavePath + "/" + Glib::path_get_basename(image->get_filename()), image);
+
+        m_StatusBar->set_message(_("Saving image to ") + m_LastSavePath);
     }
     else
     {

--- a/src/booru/browser.cc
+++ b/src/booru/browser.cc
@@ -160,6 +160,34 @@ void Browser::on_save_image()
     if (get_active_page()->is_saving())
         return;
 
+    const std::shared_ptr<Image> image =
+        std::static_pointer_cast<Image>(get_active_page()->get_imagelist()->get_current());
+
+    if (!m_LastSavePath.empty())
+    {
+        get_active_page()->save_image(m_LastSavePath + "/" + Glib::path_get_basename(image->get_filename()), image);
+    }
+    else{
+		auto* window{ static_cast<Gtk::Window*>(get_toplevel()) };
+		auto dialog{ Gtk::FileChooserNative::create(
+			"Save Image As", *window, Gtk::FILE_CHOOSER_ACTION_SAVE) };
+		dialog->set_modal();
+
+		dialog->set_current_name(Glib::path_get_basename(image->get_filename()));
+		if (dialog->run() == Gtk::RESPONSE_ACCEPT)
+		{
+			std::string path = dialog->get_filename();
+			m_LastSavePath   = Glib::path_get_dirname(path);
+			get_active_page()->save_image(path, image);
+		}
+    }
+}
+
+void Browser::on_save_image_as()
+{
+    if (get_active_page()->is_saving())
+        return;
+
     auto* window{ static_cast<Gtk::Window*>(get_toplevel()) };
     auto dialog{ Gtk::FileChooserNative::create(
         "Save Image As", *window, Gtk::FILE_CHOOSER_ACTION_SAVE) };

--- a/src/booru/browser.h
+++ b/src/booru/browser.h
@@ -42,6 +42,7 @@ namespace AhoViewer
             void on_new_tab();
             void on_close_tab();
             void on_save_image();
+            void on_save_image_as();
             void on_save_images();
             void on_view_post() const;
             void on_copy_image_url();

--- a/src/booru/browser.h
+++ b/src/booru/browser.h
@@ -86,6 +86,7 @@ namespace AhoViewer
 
             bool check_saving_page();
             void connect_image_signals(const std::shared_ptr<Image> bimage);
+            void save_image_as();
 
             std::shared_ptr<Site> get_active_site() const
             {

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -1471,6 +1471,8 @@ void MainWindow::on_save_image()
                 m_ActiveImageList->get_current()) };
 
             image->save(m_LastSavePath + "/" + Glib::path_get_basename(image->get_filename()));
+
+            m_StatusBar->set_message(_("Saving image to ") + m_LastSavePath);
         }
         else
         {

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -606,7 +606,12 @@ void MainWindow::create_actions()
                        sigc::mem_fun(m_BooruBrowser, &Booru::Browser::on_new_tab));
     m_ActionGroup->add(
         Gtk::Action::create(
-            "SaveImage", Gtk::Stock::SAVE_AS, _("Save Image as..."), _("Save the selected image")),
+            "SaveImageAs", Gtk::Stock::SAVE_AS, _("Save Image as..."), _("Save the selected image with file chooser")),
+        Gtk::AccelKey(Settings.get_keybinding("BooruBrowser", "SaveImageAs")),
+        sigc::mem_fun(*this, &MainWindow::on_save_image_as));
+    m_ActionGroup->add(
+        Gtk::Action::create(
+            "SaveImage", Gtk::Stock::SAVE, _("Save Image"), _("Save the selected image")),
         Gtk::AccelKey(Settings.get_keybinding("BooruBrowser", "SaveImage")),
         sigc::mem_fun(*this, &MainWindow::on_save_image));
     m_ActionGroup->add(
@@ -1425,6 +1430,42 @@ void MainWindow::on_toggle_slideshow()
 }
 
 void MainWindow::on_save_image()
+{
+    const Booru::Page* page{ m_BooruBrowser->get_active_page() };
+    bool archive{ !m_LocalImageList->empty() && m_LocalImageList == m_ActiveImageList &&
+                  m_LocalImageList->from_archive() },
+        booru{ page && page->get_imagelist() == m_ActiveImageList };
+
+    if (booru)
+    {
+        m_BooruBrowser->on_save_image();
+    }
+    else if (archive)
+    {
+        const auto image{ std::static_pointer_cast<Archive::Image>(
+            m_ActiveImageList->get_current()) };
+
+        if (!m_LastSavePath.empty())
+        {
+            image->save(m_LastSavePath + "/" + Glib::path_get_basename(image->get_filename()));
+        }
+        else{
+			auto dialog{ Gtk::FileChooserNative::create(
+				"Save Image As", *this, Gtk::FILE_CHOOSER_ACTION_SAVE) };
+			dialog->set_modal();
+			dialog->set_current_name(Glib::path_get_basename(image->get_filename()));
+
+			if (dialog->run() == Gtk::RESPONSE_ACCEPT)
+			{
+				std::string path = dialog->get_filename();
+				m_LastSavePath   = Glib::path_get_dirname(path);
+				image->save(path);
+			}
+        }
+    }
+}
+
+void MainWindow::on_save_image_as()
 {
     const Booru::Page* page{ m_BooruBrowser->get_active_page() };
     bool archive{ !m_LocalImageList->empty() && m_LocalImageList == m_ActiveImageList &&

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -604,11 +604,12 @@ void MainWindow::create_actions()
     m_ActionGroup->add(Gtk::Action::create("NewTab", Gtk::Stock::ADD, _("New Tab"), _("New Tab")),
                        Gtk::AccelKey(Settings.get_keybinding("BooruBrowser", "NewTab")),
                        sigc::mem_fun(m_BooruBrowser, &Booru::Browser::on_new_tab));
-    m_ActionGroup->add(
-        Gtk::Action::create(
-            "SaveImageAs", Gtk::Stock::SAVE_AS, _("Save Image as..."), _("Save the selected image with file chooser")),
-        Gtk::AccelKey(Settings.get_keybinding("BooruBrowser", "SaveImageAs")),
-        sigc::mem_fun(*this, &MainWindow::on_save_image_as));
+    m_ActionGroup->add(Gtk::Action::create("SaveImageAs",
+                                           Gtk::Stock::SAVE_AS,
+                                           _("Save Image as..."),
+                                           _("Save the selected image with file chooser")),
+                       Gtk::AccelKey(Settings.get_keybinding("BooruBrowser", "SaveImageAs")),
+                       sigc::mem_fun(*this, &MainWindow::on_save_image_as));
     m_ActionGroup->add(
         Gtk::Action::create(
             "SaveImage", Gtk::Stock::SAVE, _("Save Image"), _("Save the selected image")),
@@ -1449,18 +1450,19 @@ void MainWindow::on_save_image()
         {
             image->save(m_LastSavePath + "/" + Glib::path_get_basename(image->get_filename()));
         }
-        else{
-			auto dialog{ Gtk::FileChooserNative::create(
-				"Save Image As", *this, Gtk::FILE_CHOOSER_ACTION_SAVE) };
-			dialog->set_modal();
-			dialog->set_current_name(Glib::path_get_basename(image->get_filename()));
+        else
+        {
+            auto dialog{ Gtk::FileChooserNative::create(
+                "Save Image As", *this, Gtk::FILE_CHOOSER_ACTION_SAVE) };
+            dialog->set_modal();
+            dialog->set_current_name(Glib::path_get_basename(image->get_filename()));
 
-			if (dialog->run() == Gtk::RESPONSE_ACCEPT)
-			{
-				std::string path = dialog->get_filename();
-				m_LastSavePath   = Glib::path_get_dirname(path);
-				image->save(path);
-			}
+            if (dialog->run() == Gtk::RESPONSE_ACCEPT)
+            {
+                std::string path = dialog->get_filename();
+                m_LastSavePath   = Glib::path_get_dirname(path);
+                image->save(path);
+            }
         }
     }
 }

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -135,6 +135,7 @@ MainWindow::MainWindow(BaseObjectType* cobj, Glib::RefPtr<Gtk::Builder> bldr)
                                               "oliwer",
                                               "HaxtonFale",
                                               "WebFreak001",
+                                              "theKlanc",
                                           });
     }
     // }}}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -83,6 +83,7 @@ namespace AhoViewer
         void on_first_image();
         void on_toggle_slideshow();
         void on_save_image();
+        void on_save_image_as();
         // }}}
 
         static PreferencesDialog* m_PreferencesDialog;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -52,6 +52,7 @@ namespace AhoViewer
         void set_sensitives();
         void set_booru_sensitives();
         void update_title();
+        void save_image_as();
 
         bool is_fullscreen() const;
 

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -107,7 +107,8 @@ SettingsManager::SettingsManager()
           { "BooruBrowser",
             {
                 { "NewTab", "<Primary>t" },
-                { "SaveImage", "<Primary>s" },
+                { "SaveImage", "<Shift>s" },
+                { "SaveImageAs", "<Primary>s" },
                 { "SaveImages", "<Primary><Shift>s" },
                 { "ViewPost", "<Primary><Shift>o" },
                 { "CopyImageURL", "y" },

--- a/src/ui/ahoviewer.ui
+++ b/src/ui/ahoviewer.ui
@@ -2054,6 +2054,7 @@
       <accelerator action="ScrollRight"/>
       <accelerator action="NewTab"/>
       <accelerator action="SaveImage"/>
+      <accelerator action="SaveImageAs"/>
       <accelerator action="SaveImages"/>
       <popup name="PopupMenu">
         <menuitem action="OpenFile"/>
@@ -2087,6 +2088,7 @@
       </popup>
       <popup name="BooruPopupMenu">
         <menuitem action="SaveImage"/>
+        <menuitem action="SaveImageAs"/>
         <separator/>
         <menuitem action="ViewPost"/>
         <menuitem action="CopyImageURL"/>


### PR DESCRIPTION
Implemented https://github.com/ahodesuka/ahoviewer/issues/107 by separating Save Image into two different actions, one with dialog and one without (will still launch a save dialog if there's no default save path)