### PR TITLE
fix compiling without gstreamer, libpeas

### DIFF
--- a/src/booru/site.cc
+++ b/src/booru/site.cc
@@ -133,7 +133,7 @@ std::shared_ptr<Site> Site::create(const std::string& name,
 #else  // !HAVE_LIBPEAS
         auto t{ get_type_from_url(url) };
         if (t != Type::UNKNOWN)
-            return std::make_shared<SharedSite>(name, url, t, user, pass, use_samples);
+            return std::make_shared<SharedSite>(name, url, t, user, pass, use_samples, user_agent);
 #endif // !HAVE_LIBPEAS
     }
     else

--- a/src/imagebox.cc
+++ b/src/imagebox.cc
@@ -431,10 +431,12 @@ void ImageBox::draw_image(bool scroll)
             error = true;
         }
     }
+#ifdef HAVE_GSTREAMER
     else if (!m_VideoBox->is_playing())
     {
         std::tie(error, m_OrigWidth, m_OrigHeight) = m_VideoBox->load_file(m_Image->get_path());
     }
+#endif // HAVE_GSTREAMER
 
     if (error)
     {
@@ -473,6 +475,7 @@ void ImageBox::draw_image(bool scroll)
         m_GtkImage->set(temp_pixbuf);
         m_Overlay->show();
     }
+#ifdef HAVE_GSTREAMER
     else
     {
         if (!m_VideoBox->is_playing())
@@ -485,6 +488,7 @@ void ImageBox::draw_image(bool scroll)
         m_Fixed->move(*m_VideoBox, x, y);
         m_VideoBox->set_size_request(w, h);
     }
+#endif // HAVE_GSTREAMER
 
     // Reset the scrollbar positions
     if (scroll || m_FirstDraw)
@@ -523,9 +527,11 @@ void ImageBox::draw_image(bool scroll)
         m_ZoomScroll = false;
     }
 
+#ifdef HAVE_GSTREAMER
     // Finally start playing the video
     if (!error && !m_VideoBox->is_playing() && m_Image->is_webm())
         m_VideoBox->start();
+#endif // HAVE_GSTREAMER
 
     get_window()->thaw_updates();
     m_RedrawQueued = false;
@@ -684,10 +690,14 @@ bool ImageBox::advance_slideshow()
 
 bool ImageBox::on_cursor_timeout()
 {
+#ifdef HAVE_GSTREAMER
     // hide_controls will return false if the cursor is over the controls widget
     // meaning we should not hide the cursor
     if (!m_VideoBox->is_playing() || m_VideoBox->hide_controls(true))
         m_Fixed->get_window()->set_cursor(m_BlankCursor);
+#else  // !HAVE_GSTREAMER
+    m_Fixed->get_window()->set_cursor(m_BlankCursor);
+#endif // !HAVE_GSTREAMER
 
     return false;
 }

--- a/src/keybindingeditor.cc
+++ b/src/keybindingeditor.cc
@@ -50,6 +50,7 @@ KeybindingEditor::KeybindingEditor(BaseObjectType* cobj, const Glib::RefPtr<Gtk:
         it->set_value(m_Columns.name, std::string{ cat.data() });
         cat_iters.emplace(cat, it);
     }
+#ifdef HAVE_LIBPEAS
     static constexpr auto is_plugin_loaded = [&](const std::string& action_name) {
         const auto& plugins{
             Application::get_default()->get_plugin_manager().get_window_plugins()
@@ -59,6 +60,7 @@ KeybindingEditor::KeybindingEditor(BaseObjectType* cobj, const Glib::RefPtr<Gtk:
         }) };
         return it != plugins.end();
     };
+#endif // HAVE_LIBPEAS
 
     // Add the keybindings to the treeview model
     for (const auto& [name, binds] : Settings.get_keybindings())

--- a/src/videobox.cc
+++ b/src/videobox.cc
@@ -60,8 +60,11 @@ gboolean VideoBox::bus_cb(GstBus*, GstMessage* msg, void* userp)
 #endif // HAVE_GSTREAMER
 
 VideoBox::VideoBox(BaseObjectType* cobj, const Glib::RefPtr<Gtk::Builder>& bldr)
-    : Gtk::Overlay{ cobj },
+    : Gtk::Overlay{ cobj }
+#ifdef HAVE_GSTREAMER
+      ,
       m_Mute{ Settings.get_bool("Mute") }
+#endif // HAVE_GSTREAMER
 {
     bldr->get_widget("VideoBox::ControlRevealer", m_ControlRevealer);
     bldr->get_widget("VideoBox::PlayPauseButton", m_PlayPauseButton);
@@ -79,7 +82,7 @@ VideoBox::VideoBox(BaseObjectType* cobj, const Glib::RefPtr<Gtk::Builder>& bldr)
         "vaapih264dec",    "vaapimpeg2dec",  "vaapivc1dec",
 #ifdef _WIN32
         "d3d11h264dec",    "d3d11h265dec",   "d3d11vp8dec", "d3d11vp9dec",
-#endif
+#endif // _WIN32
     };
     GstRegistry* plugins_register{ gst_registry_get() };
 
@@ -292,6 +295,7 @@ void VideoBox::start()
 
 bool VideoBox::hide_controls(bool skip_timeout)
 {
+#ifdef HAVE_GSTREAMER
     m_HideConn.disconnect();
     // Don't hide if the cursor is currently inside the control widget
     if (m_HoveringControls)
@@ -306,6 +310,7 @@ bool VideoBox::hide_controls(bool skip_timeout)
         skip_timeout ? 0 : 500);
 
     m_ShowControls = false;
+#endif // HAVE_GSTREAMER
 
     return true;
 }

--- a/src/videobox.h
+++ b/src/videobox.h
@@ -22,7 +22,9 @@ namespace AhoViewer
         std::tuple<bool, int, int> load_file(const std::string& path);
         void start();
 
+#ifdef HAVE_GSTREAMER
         bool is_playing() const { return m_Playing; };
+#endif // HAVE_GSTREAMER
 
         bool hide_controls(bool skip_timeout = false);
 
@@ -31,9 +33,9 @@ namespace AhoViewer
         Gtk::Button *m_PlayPauseButton, *m_VolumeButton;
         Gtk::Label *m_PosLabel, *m_DurLabel;
         Gtk::Scale *m_VolumeScale, *m_SeekScale;
+#ifdef HAVE_GSTREAMER
         Gtk::Widget* m_GstWidget;
 
-#ifdef HAVE_GSTREAMER
         static gboolean bus_cb(GstBus*, GstMessage* msg, void* userp);
         static void on_about_to_finish(GstElement*, void* userp);
 


### PR DESCRIPTION
I wasn't able to compile the latest master on GNU/Linux without the optional dependencies gstreamer and libpeas installed.  
It works with these changes.